### PR TITLE
change "prepare" to "prepack" in canvas-trading

### DIFF
--- a/packages/canvas-trading/package.json
+++ b/packages/canvas-trading/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "postinstall": "npm run build"
   },
   "keywords": [],


### PR DESCRIPTION
prepare was causing double-builds in tandem with postinstall